### PR TITLE
trying to render an object that is the result of _cu_atoz_render_chil…

### DIFF
--- a/modules/custom/cu_atoz/cu_atoz.module
+++ b/modules/custom/cu_atoz/cu_atoz.module
@@ -140,7 +140,8 @@ function _cu_atoz_render_children($orgunit) {
     $output['children']['#prefix'] = '<div class="atoz-subunits">';
     $output['children']['#suffix'] = '</div>';
     foreach($orgunit->children_ous as $child_orgunit) {
-      $output['children']['#items'][] = render(_cu_atoz_render_children($child_orgunit));
+      $clone = _cu_atoz_render_children($child_orgunit);
+      $output['children']['#items'][] = drupal_render($clone);
     }
   }
   return $output;


### PR DESCRIPTION
…dren function resulted in a 'only variables should be passed by reference' error.  The solution was to add an additional step setting the object returned by _cu_atoz_render_children to a variable and then rendering that.